### PR TITLE
Replace img tags with Image component in publications section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,10 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Sns from "../components/Sns.astro";
+import { Image } from "astro:assets";
+import localIsuconBookImage from "../../public/img/isucon.jpg";
+import localSoftwareDesignBookImage from "../../public/img/sd.jpg";
+import localPixivBookImage from "../../public/img/pixiv.png";
 ---
 
 <Layout title="catatsuy's Website">
@@ -96,13 +100,34 @@ import Sns from "../components/Sns.astro";
     <h2>Publications</h2>
     <h3>Books</h3>
     <a target="_blank" href="https://amzn.to/3NpUMtx">
-      <img src="/img/isucon.jpg" class="book" alt="ISUCON" />
+      <Image
+        src={localIsuconBookImage}
+        format="avif"
+        quality="high"
+        height="200"
+        class="book"
+        alt="ISUCON"
+      />
     </a>
     <a target="_blank" href="https://amzn.to/3r5Go4c">
-      <img src="/img/sd.jpg" class="book" alt="Software Design 2023/10" />
+      <Image
+        src={localSoftwareDesignBookImage}
+        format="avif"
+        quality="high"
+        height="200"
+        class="book"
+        alt="Software Design 2023/10"
+      />
     </a>
     <a target="_blank" href="https://amzn.to/2GckB2B">
-      <img src="/img/pixiv.png" class="book" alt="pixiv" />
+      <Image
+        src={localPixivBookImage}
+        format="avif"
+        quality="high"
+        height="200"
+        class="book"
+        alt="pixiv"
+      />
     </a>
   </main>
 </Layout>


### PR DESCRIPTION
This pull request primarily focuses on improving the image handling in the `src/pages/index.astro` file. The changes include importing the `Image` component from `astro:assets` and local images for book covers, and replacing the old image tags with the new `Image` component for better image optimization.

Here are the key changes:

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R4-R7): Imported the `Image` component from `astro:assets` and local images for book covers.
* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L99-R130): Replaced the old `<img>` tags with the new `Image` component, providing properties such as `src`, `format`, `quality`, `height`, `class`, and `alt` for better image optimization.