### PR TITLE
Add LinkedIn SNS link to index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,11 @@ import localPixivBookImage from "../../public/img/pixiv.png";
         icon="fa-youtube"
         sns="YouTube"
       />
+      <Sns
+        href="https://www.linkedin.com/in/catatsuy"
+        icon="fa-linkedin"
+        sns="LinkedIn"
+      />
     </ul>
     <h3>Other Platforms</h3>
     <ul>


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/index.astro` file. The change adds a new social media link to the LinkedIn profile.

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663R30-R34): Added a new `Sns` component for LinkedIn with the appropriate `href`, `icon`, and `sns` attributes.