### PR TITLE
Update graduation year from 2023 to 2013 in index.astro file

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -77,7 +77,7 @@ import localPixivBookImage from "../../public/img/pixiv.png";
         Bachelor of Engineering in Computer Science from
         <a href="https://www.titech.ac.jp/" target="_blank">
           Tokyo Institute of Technology</a
-        >, Department of Engineering, graduated in 2023/09
+        >, Department of Engineering, graduated in 2013/09
       </li>
     </ul>
     <h2>Professional Experience</h2>


### PR DESCRIPTION
This pull request includes a small but important correction to the graduation year in the `src/pages/index.astro` file.

* Corrected the graduation year from "2023/09" to "2013/09" in the Tokyo Institute of Technology section.