### PR TITLE
Update education details and link to the Institute of Science Tokyo

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,8 +76,12 @@ import localPixivBookImage from "../../public/img/pixiv.png";
       <li>
         Bachelor of Engineering in Computer Science from
         <a href="https://www.titech.ac.jp/" target="_blank">
-          Tokyo Institute of Technology</a
-        >, Department of Engineering, graduated in 2013/09
+          Tokyo Institute of Technology
+        </a>
+        (now
+        <a href="https://www.isct.ac.jp/" target="_blank">
+          Institute of Science Tokyo</a
+        >), Faculty of Engineering, graduated in 2013/09
       </li>
     </ul>
     <h2>Professional Experience</h2>


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/index.astro` file. The change updates the name and link of the Tokyo Institute of Technology to its new name, Institute of Science Tokyo, in the education section.

* [`src/pages/index.astro`](diffhunk://#diff-95d291e9ce4c8739cc7e65ff7bf0838dd5294cf39ab787ba51a42d08fb2df663L79-R84): Updated the name and link of Tokyo Institute of Technology to Institute of Science Tokyo in the education section.