### PR TITLE
Add dummy Early Hints CSS/JS and preload in Layout.astro

### DIFF
--- a/public/css/ea.css
+++ b/public/css/ea.css
@@ -1,0 +1,2 @@
+/* Dummy settings for Early Hints */
+:root {}

--- a/public/js/ea.js
+++ b/public/js/ea.js
@@ -1,0 +1,2 @@
+// Dummy settings for Early Hints
+void 0;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,6 +25,9 @@ const { title } = Astro.props;
       sizes="16x16 32x32 48x48"
       type="image/vnd.microsoft.icon"
     />
+    <link rel="preload" href="/css/ea.css" as="style">
+    <link rel="preload" href="/js/ea.js" as="script">
+    <link rel="stylesheet" href="/css/ea.css" />
     <title>{title}</title>
   </head>
   <body>
@@ -48,6 +51,7 @@ const { title } = Astro.props;
 
       gtag("config", "G-WZLF1ZEM6T");
     </script>
+    <script src="/js/ea.js" defer></script>
   </body>
 </html>
 <style is:global>


### PR DESCRIPTION
This pull request introduces basic scaffolding for Early Hints support by adding placeholder CSS and JavaScript files, and updating the main layout to preload and include these resources. The changes are primarily preparatory, setting up the structure for future Early Hints optimizations.

Resource inclusion and preloading:

* Updated `src/layouts/Layout.astro` to preload and include the new `ea.css` stylesheet and `ea.js` script, ensuring they are loaded early in the page lifecycle. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R28-R30) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R54)

Early Hints resource stubs:

* Created a placeholder CSS file `public/css/ea.css` with a dummy root selector for Early Hints.
* Added a placeholder JavaScript file `public/js/ea.js` with a dummy statement for Early Hints.