### PR TITLE
import FontAwesome CSS directly in Layout.astro instead of global style

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import Footer from "../components/Footer.astro";
+import "@fortawesome/fontawesome-free/css/all.min.css";
 
 export interface Props {
   title: string;
@@ -55,8 +56,6 @@ const { title } = Astro.props;
   </body>
 </html>
 <style is:global>
-  @import "@fortawesome/fontawesome-free/css/all.min.css";
-
   html {
     font-family: system-ui, sans-serif;
     background-color: #f6f6f6;


### PR DESCRIPTION
This pull request updates how the Font Awesome CSS is imported in the `Layout.astro` file. The import is moved from a global CSS import in the `<style>` block to a direct JavaScript import at the top of the file, which is the preferred way to include external CSS in Astro components.

Styling and asset management:

* Moved the Font Awesome CSS import from the global `<style>` block to a JavaScript import at the top of the `Layout.astro` file for better asset management and compatibility with Astro's recommended practices. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2R3) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L58-L59)