### PR TITLE
reorder podcast link in social media list for consistency

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,11 +16,6 @@ import localPixivBookImage from "../../public/img/pixiv.png";
     <h3>Social Media</h3>
     <ul role="list" class="sns">
       <Sns
-        href="https://listen.style/p/weekend_oss"
-        icon="fa-solid fa-podcast"
-        sns="Podcast"
-      />
-      <Sns
         href="https://x.com/catatsuy"
         icon="fa-brands fa-x-twitter"
         sns="X"
@@ -44,6 +39,11 @@ import localPixivBookImage from "../../public/img/pixiv.png";
         href="https://www.linkedin.com/in/catatsuy"
         icon="fa-brands fa-linkedin"
         sns="LinkedIn"
+      />
+      <Sns
+        href="https://listen.style/p/weekend_oss"
+        icon="fa-solid fa-podcast"
+        sns="Podcast"
       />
     </ul>
     <h3>Other Platforms</h3>


### PR DESCRIPTION
This pull request makes a minor adjustment to the order of social media links on the profile page. The Podcast link is moved to appear after the LinkedIn link instead of before the Twitter link.