### PR TITLE
Update Podcast link and add Weekend OSS to archived links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,10 +32,10 @@ const socialLinks = [
     handle: "@catatsuy",
   },
   {
-    href: "https://listen.style/p/weekend_oss",
+    href: "https://yaoyorozu-oss.henteko07.com/",
     icon: "fa-solid fa-podcast",
     sns: "Podcast",
-    handle: "Weekend OSS",
+    handle: "八百万のOSS",
   },
   {
     href: "https://facebook.com/catatsuy",
@@ -91,6 +91,10 @@ const archivedLinks = [
   {
     title: "Qiita",
     href: "https://qiita.com/catatsuy",
+  },
+  {
+    title: "Weekend OSS",
+    href: "https://listen.style/p/weekend_oss",
   },
   {
     title: "catatsuyとは",


### PR DESCRIPTION
This pull request updates the podcast link and display name in the main social links section and moves the previous podcast link to the archived links section on the `index.astro` page.

**Social links update:**

* Updated the podcast social link to use the new URL (`https://yaoyorozu-oss.henteko07.com/`) and changed the display name from "Weekend OSS" to "八百万のOSS".

**Archived links update:**

* Added the previous "Weekend OSS" podcast link (`https://listen.style/p/weekend_oss`) to the `archivedLinks` section.